### PR TITLE
feat: add queue manager table option

### DIFF
--- a/index
+++ b/index
@@ -50,6 +50,7 @@
         <option value="casemanager">Case Manager</option>
         <option value="maintable">Main Table</option>
         <option value="billed_ar_aging">Billed AR Aging</option>
+        <option value="queue_manager">Queue Manager</option>
         <!-- ✅ FIX: send correct table name for Unduplicated importer -->
         <option value="unduplicatedpatients">Unduplicated Census</option>
       </select>


### PR DESCRIPTION
## Summary
- allow CSV uploads to Queue Manager by adding the table option in the upload form

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4adfdd68c832caab5c7ee3e32e48e