### PR TITLE
Use composite MRN/period key for PDGM import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "index-processor",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "NODE_ENV=test node tests/pdgm_import.test.js"
+  },
+  "dependencies": {
+    "pg": "^8.11.3"
+  }
+}

--- a/tests/csv-parse-stub.js
+++ b/tests/csv-parse-stub.js
@@ -1,0 +1,5 @@
+module.exports = {
+  parse: () => {
+    throw new Error('csv-parse stub should not be invoked during tests.');
+  },
+};

--- a/tests/csv-stringify-stub.js
+++ b/tests/csv-stringify-stub.js
@@ -1,0 +1,5 @@
+module.exports = {
+  stringify: () => {
+    throw new Error('csv-stringify stub should not be invoked during tests.');
+  },
+};

--- a/tests/express-stub.js
+++ b/tests/express-stub.js
@@ -1,0 +1,22 @@
+function noopMiddleware() {
+  return (req, res, next) => {
+    if (typeof next === 'function') next();
+  };
+}
+
+function createExpress() {
+  return {
+    use: () => {},
+    post: () => {},
+    get: () => {},
+    listen: (port, cb) => {
+      if (typeof cb === 'function') cb();
+      return { close: () => {} };
+    },
+  };
+}
+
+createExpress.static = noopMiddleware;
+createExpress.urlencoded = () => noopMiddleware();
+
+module.exports = createExpress;

--- a/tests/fakeClient.js
+++ b/tests/fakeClient.js
@@ -1,0 +1,52 @@
+class FakeClient {
+  constructor() {
+    this.storage = new Map();
+  }
+
+  async query(sql, params = []) {
+    if (!/^\s*INSERT\s+INTO\s+"pdgm"/i.test(sql)) {
+      throw new Error(`FakeClient received unsupported query: ${sql}`);
+    }
+
+    const insertMatch = sql.match(/INSERT\s+INTO\s+"pdgm"\s*\(([^)]+)\)/i);
+    if (!insertMatch) {
+      throw new Error('Unable to parse INSERT statement for columns.');
+    }
+    const columns = insertMatch[1]
+      .split(',')
+      .map(part => part.trim().replace(/"/g, ''));
+
+    const conflictMatch = sql.match(/ON\s+CONFLICT\s*\(([^)]+)\)/i);
+    if (!conflictMatch) {
+      throw new Error('Unable to parse conflict columns.');
+    }
+    const conflictColumns = conflictMatch[1]
+      .split(',')
+      .map(part => part.trim().replace(/"/g, ''));
+
+    const rowWidth = columns.length;
+    if (params.length % rowWidth !== 0) {
+      throw new Error('Parameter length does not align with columns.');
+    }
+
+    const rowCount = params.length / rowWidth;
+    for (let i = 0; i < rowCount; i++) {
+      const rowValues = params.slice(i * rowWidth, (i + 1) * rowWidth);
+      const record = {};
+      columns.forEach((col, idx) => {
+        record[col] = rowValues[idx];
+      });
+
+      const key = conflictColumns.map(col => record[col]).join('|');
+      this.storage.set(key, record);
+    }
+
+    return { rowCount };
+  }
+
+  getAllRows() {
+    return Array.from(this.storage.values());
+  }
+}
+
+module.exports = FakeClient;

--- a/tests/multer-stub.js
+++ b/tests/multer-stub.js
@@ -1,0 +1,12 @@
+function multer() {
+  return {
+    single: () => (req, res, next) => {
+      if (typeof next === 'function') next();
+    },
+    any: () => (req, res, next) => {
+      if (typeof next === 'function') next();
+    },
+  };
+}
+
+module.exports = multer;

--- a/tests/pdgm_import.test.js
+++ b/tests/pdgm_import.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+const FakeClient = require('./fakeClient');
+const {
+  processBatch,
+  setClientForTesting,
+  normalizeDateForPg,
+} = require('../pdgm');
+
+(async () => {
+  const client = new FakeClient();
+  setClientForTesting(client);
+
+  const tableColumns = ['Some Field'];
+  const keyColumns = ['MRN', 'Period Start Date'];
+
+  await processBatch(
+    [
+      { keys: ['12345', normalizeDateForPg('01/01/2024')], rowData: ['Alpha'] },
+      { keys: ['12345', normalizeDateForPg('02/01/2024')], rowData: ['Beta'] },
+    ],
+    'pdgm',
+    tableColumns,
+    keyColumns
+  );
+
+  const rows = client
+    .getAllRows()
+    .map(r => ({
+      mrn: r.MRN,
+      periodStart: r['Period Start Date'],
+      value: r['Some Field'],
+    }))
+    .sort((a, b) => a.periodStart.localeCompare(b.periodStart));
+
+  assert.strictEqual(rows.length, 2, 'Expected two PDGM rows for distinct periods');
+  assert.deepStrictEqual(
+    rows.map(r => r.periodStart),
+    ['2024-01-01', '2024-02-01'],
+    'Period start dates should remain distinct'
+  );
+  assert.deepStrictEqual(rows.map(r => r.value), ['Alpha', 'Beta']);
+
+  console.log('✅ PDGM composite key import test passed');
+})().catch(err => {
+  console.error('❌ PDGM composite key import test failed');
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/pg-copy-streams-stub.js
+++ b/tests/pg-copy-streams-stub.js
@@ -1,0 +1,5 @@
+module.exports = {
+  from: () => {
+    throw new Error('pg-copy-streams stub should not be invoked during tests.');
+  },
+};

--- a/tests/pg-stub.js
+++ b/tests/pg-stub.js
@@ -1,0 +1,14 @@
+class StubClient {
+  constructor() {}
+  connect() {
+    return Promise.resolve();
+  }
+  query() {
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  }
+  end() {
+    return Promise.resolve();
+  }
+}
+
+module.exports = { Client: StubClient };


### PR DESCRIPTION
## Summary
- ensure the pdgm table enforces a unique index on the combination of MRN and Period Start Date
- update the PDGM importer to normalize period start headers/dates, use composite keys for upserts and cleanup, and guard test-time dependencies
- add a lightweight test harness that verifies rows with the same MRN but different period starts both persist after processing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e27c102b7c832cb633007376a64996