### PR TITLE
Add Referrals table option to uploader form

### DIFF
--- a/index
+++ b/index
@@ -55,6 +55,7 @@
         <option value="unduplicatedpatients">Unduplicated Census</option>
         <option value="active_agency">Active Agency Census</option>
         <option value="pdgm">PDGM</option>
+        <option value="referrals">Referrals</option>
       </select>
 
       <label for="csvFile">Choose CSV File:</label>
@@ -62,7 +63,7 @@
 
       <button type="submit">Upload</button>
     </form>
-    <div class="muted">Tip: Main Table requires a "Visit ID". Unduplicated and PDGM require "MRN".</div>
+    <div class="muted">Tip: Main Table requires a "Visit ID". Unduplicated, PDGM, and Referrals require an "MRN" key.</div>
     <div id="status"></div>
   </div>
 


### PR DESCRIPTION
## Summary
- add Referrals to the table selection dropdown in the CSV uploader
- clarify helper text that Referrals requires an MRN key alongside the other MRN-dependent tables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d82a8f48832c833b0e879028e0d6