### PR TITLE
Add referrals importer with MRN constraint and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "commonjs",
   "scripts": {
-    "test": "NODE_ENV=test node tests/pdgm_import.test.js"
+    "test": "NODE_ENV=test node tests/pdgm_import.test.js && NODE_ENV=test node tests/referrals_import.test.js"
   },
   "dependencies": {
     "pg": "^8.11.3"

--- a/tests/fakeClient.js
+++ b/tests/fakeClient.js
@@ -1,47 +1,82 @@
 class FakeClient {
-  constructor() {
+  constructor(options = {}) {
+    if (typeof options === 'string') {
+      this.tableName = options;
+    } else {
+      this.tableName = options.tableName || 'pdgm';
+    }
     this.storage = new Map();
+    this.lastConflictColumns = [];
   }
 
   async query(sql, params = []) {
-    if (!/^\s*INSERT\s+INTO\s+"pdgm"/i.test(sql)) {
-      throw new Error(`FakeClient received unsupported query: ${sql}`);
+    const tableName = this.tableName.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    const insertRegex = new RegExp(`^\\s*INSERT\\s+INTO\\s+"${tableName}"`, 'i');
+    const deleteRegex = new RegExp(`^\\s*DELETE\\s+FROM\\s+"${tableName}"`, 'i');
+
+    if (insertRegex.test(sql)) {
+      const insertMatch = sql.match(new RegExp(`INSERT\\s+INTO\\s+"${tableName}"\\s*\\(([^)]+)\\)`, 'i'));
+      if (!insertMatch) {
+        throw new Error('Unable to parse INSERT statement for columns.');
+      }
+      const columns = insertMatch[1]
+        .split(',')
+        .map(part => part.trim().replace(/"/g, ''));
+
+      const conflictMatch = sql.match(/ON\s+CONFLICT\s*\(([^)]+)\)/i);
+      if (!conflictMatch) {
+        throw new Error('Unable to parse conflict columns.');
+      }
+      const conflictColumns = conflictMatch[1]
+        .split(',')
+        .map(part => part.trim().replace(/"/g, ''));
+
+      this.lastConflictColumns = conflictColumns;
+
+      const rowWidth = columns.length;
+      if (params.length % rowWidth !== 0) {
+        throw new Error('Parameter length does not align with columns.');
+      }
+
+      const rowCount = params.length / rowWidth;
+      for (let i = 0; i < rowCount; i++) {
+        const rowValues = params.slice(i * rowWidth, (i + 1) * rowWidth);
+        const record = {};
+        columns.forEach((col, idx) => {
+          record[col] = rowValues[idx];
+        });
+
+        const key = conflictColumns.map(col => record[col]).join('|');
+        this.storage.set(key, record);
+      }
+
+      return { rowCount };
     }
 
-    const insertMatch = sql.match(/INSERT\s+INTO\s+"pdgm"\s*\(([^)]+)\)/i);
-    if (!insertMatch) {
-      throw new Error('Unable to parse INSERT statement for columns.');
-    }
-    const columns = insertMatch[1]
-      .split(',')
-      .map(part => part.trim().replace(/"/g, ''));
+    if (deleteRegex.test(sql)) {
+      const whereMatch = sql.match(/WHERE\s+"([^"\s]+)"\s*=\s*ANY\(\$1\)/i);
+      if (!whereMatch) {
+        throw new Error('Unable to parse DELETE statement for key column.');
+      }
 
-    const conflictMatch = sql.match(/ON\s+CONFLICT\s*\(([^)]+)\)/i);
-    if (!conflictMatch) {
-      throw new Error('Unable to parse conflict columns.');
-    }
-    const conflictColumns = conflictMatch[1]
-      .split(',')
-      .map(part => part.trim().replace(/"/g, ''));
+      const keyColumn = whereMatch[1];
+      const ids = Array.isArray(params[0]) ? params[0] : [];
+      const idSet = new Set(ids.map(v => (v === null || v === undefined ? v : String(v))));
+      let deleted = 0;
 
-    const rowWidth = columns.length;
-    if (params.length % rowWidth !== 0) {
-      throw new Error('Parameter length does not align with columns.');
-    }
+      for (const [key, record] of Array.from(this.storage.entries())) {
+        const value = record[keyColumn];
+        const normalizedValue = value === null || value === undefined ? value : String(value);
+        if (idSet.has(normalizedValue)) {
+          this.storage.delete(key);
+          deleted++;
+        }
+      }
 
-    const rowCount = params.length / rowWidth;
-    for (let i = 0; i < rowCount; i++) {
-      const rowValues = params.slice(i * rowWidth, (i + 1) * rowWidth);
-      const record = {};
-      columns.forEach((col, idx) => {
-        record[col] = rowValues[idx];
-      });
-
-      const key = conflictColumns.map(col => record[col]).join('|');
-      this.storage.set(key, record);
+      return { rowCount: deleted };
     }
 
-    return { rowCount };
+    throw new Error(`FakeClient received unsupported query: ${sql}`);
   }
 
   getAllRows() {

--- a/tests/referrals_import.test.js
+++ b/tests/referrals_import.test.js
@@ -1,0 +1,59 @@
+const assert = require('assert');
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
+const FakeClient = require('./fakeClient');
+const {
+  processBatch,
+  setClientForTesting,
+  normalizeDateForPg,
+} = require('../pdgm');
+
+(async () => {
+  const client = new FakeClient({ tableName: 'referrals' });
+  setClientForTesting(client);
+
+  const tableColumns = ['Patient Name', 'Referral Date'];
+
+  await processBatch(
+    [
+      { keys: ['1001'], rowData: ['Alice', normalizeDateForPg('01/01/2024')] },
+      { keys: ['1001'], rowData: ['Alice Updated', normalizeDateForPg('02/01/2024')] },
+      { keys: ['2002'], rowData: ['Bob', normalizeDateForPg('03/01/2024')] },
+    ],
+    'referrals',
+    tableColumns,
+    ['MRN']
+  );
+
+  const rows = client
+    .getAllRows()
+    .map(r => ({
+      mrn: r.MRN,
+      patient: r['Patient Name'],
+      referralDate: r['Referral Date'],
+    }))
+    .sort((a, b) => a.mrn.localeCompare(b.mrn));
+
+  assert.strictEqual(rows.length, 2, 'Expected two unique MRNs after upsert');
+  assert.deepStrictEqual(
+    rows.map(r => r.patient),
+    ['Alice Updated', 'Bob'],
+    'Latest record for MRN 1001 should be retained'
+  );
+
+  const deleteResult = await client.query(
+    'DELETE FROM "referrals" WHERE "MRN" = ANY($1)',
+    [['2002']]
+  );
+
+  assert.strictEqual(deleteResult.rowCount, 1, 'Expected one row deleted for MRN 2002');
+  const remaining = client.getAllRows().map(r => r.MRN);
+  assert.deepStrictEqual(remaining, ['1001'], 'MRN 2002 should be removed after deletion');
+
+  console.log('✅ Referrals import helpers test passed');
+})().catch(err => {
+  console.error('❌ Referrals import helpers test failed');
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a helper to ensure a unique MRN index on referrals and implement the referrals importer with normalization, delete handling, and cleanup
- expand the fake PG client to support configurable tables and deletes, and add a referrals-focused unit test
- update the npm test script to run the new coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3db9b04b0832cb70ae07c0e58bd50