### PR TITLE
Add Raw Data selection to upload form

### DIFF
--- a/index
+++ b/index
@@ -56,6 +56,7 @@
         <option value="active_agency">Active Agency Census</option>
         <option value="pdgm">PDGM</option>
         <option value="referrals">Referrals</option>
+        <option value="raw_data">Raw Data</option>
       </select>
 
       <label for="csvFile">Choose CSV File:</label>
@@ -63,7 +64,7 @@
 
       <button type="submit">Upload</button>
     </form>
-    <div class="muted">Tip: Main Table requires a "Visit ID". Unduplicated, PDGM, and Referrals require an "MRN" key.</div>
+    <div class="muted">Tip: Main Table requires a "Visit ID". Raw Data requires an "Admission ID". Unduplicated, PDGM, and Referrals require an "MRN" key.</div>
     <div id="status"></div>
   </div>
 


### PR DESCRIPTION
## Summary
- add a Raw Data option to the upload table selector so operators can target the raw_data import
- document in the helper tip that Raw Data imports are keyed by Admission ID

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e42945a4832ca304aec74283fb71